### PR TITLE
Correct bug in FileChooser

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -65,13 +65,16 @@ define('dahuapp', [
     'models/objects/mouse',
     'layouts/dahuapp',
     'views/filmstrip/screens',
-    'views/workspace/screen'
+    'views/workspace/screen',
+    'collections/screens'
 ], function($, _, Backbone, Marionette, Kernel, events, reqResponse, Paths,
-            ScreencastModel, ScreenModel, BackgroundModel, MouseModel, DahuLayout, FilmstripScreensView, WorkspaceScreenView) {
+            ScreencastModel, ScreenModel, BackgroundModel, MouseModel, DahuLayout,
+            FilmstripScreensView, WorkspaceScreenView, ScreensCollection) {
 
     var projectFilename;
     var projectScreencast;
     var workSpaceScreen;
+    var screensToDelete;
 
     //
     // Application
@@ -269,6 +272,11 @@ define('dahuapp', [
         if (keyCode == '27') {
             onCaptureStop();
         }
+        // delete the selected screenshot
+        //@todo make this possible outside the capture mode
+        if (keyCode == '8') {
+            deleteSelectedScreen();
+        }
     }
 
     /**
@@ -295,6 +303,29 @@ define('dahuapp', [
         projectScreencast.get('screens').add(screen);
         // Refresh the workspace
         onScreenSelect(screen);
+    }
+
+    /**
+     * Delete the selected screenshot
+     */
+    function deleteSelectedScreen() {
+        var currentScreen = workSpaceScreen.model;
+        var id = projectScreencast.get('screens').indexOf(currentScreen);
+        var nbOfScreens = projectScreencast.get('screens').size();
+        // delete screen model
+        currentScreen = projectScreencast.get('screens').remove(currentScreen);
+        // put the picture file on a wait to delete list
+        if (screensToDelete == undefined) {
+            screensToDelete = new ScreensCollection();
+        }
+        screensToDelete.add(currentScreen);
+
+        // select the next screen to show in the workspace
+        if (id == nbOfScreens -1) {
+            id --;
+        }
+        onScreenSelect(projectScreencast.get('screens').at(id));
+
     }
 
     /**

--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -275,17 +275,18 @@ define('dahuapp', [
         // create new models
         var screen = new ScreenModel();
         var background = new BackgroundModel();
+        var mouse = new MouseModel();
         // take the screenshot
         var imgDir = Paths.getProjectImgDirectory();
         var capture = Kernel.module('media').takeCapture(imgDir, background.get('id'));
         // set the img path in background
         background.set('img', Paths.getRelativeImgPath(capture.screen));
+        // set the coordinates of the mouse cursor
+        mouse.set('posX', capture.getMouseX());
+        mouse.set('posY', capture.getMouseY());
         // Insert objects in the screen
         screen.get('objects').add(background);
-        screen.get('objects').add(new MouseModel());
-
-        //@todo insert initial mouse action in the screen
-
+        screen.get('objects').add(mouse);
         // Insert the screen in the screencast
         projectScreencast.get('screens').add(screen);
         // Refresh the workspace

--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -323,6 +323,7 @@ define('dahuapp', [
      */
     function onCaptureStart() {
         //Start listening to the keyboard events
+        Kernel.module('keyboard').start();
         Kernel.module('keyboard').addKeyListener("kernel:keyboard:onKeyRelease");
     }
 
@@ -333,6 +334,7 @@ define('dahuapp', [
     function onCaptureStop() {
         //Stop listening to the keyboard events
         Kernel.module('keyboard').removeKeyListener("kernel:keyboard:onKeyRelease");
+        Kernel.module('keyboard').stop();
     }
 
 

--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -265,6 +265,10 @@ define('dahuapp', [
         if (keyName == 'F7') {
             takeCapture();
         }
+        // capture the escape button to stop the capture mode
+        if (keyCode == '27') {
+            onCaptureStop();
+        }
     }
 
     /**

--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -132,8 +132,11 @@ define('dahuapp', [
     function initRequestResponse() {
         // Prepare a response that gives the project directory.
         reqResponse.setHandler("app:projectDirectory", function(){
-            var indexOfLastSlash = projectFilename.lastIndexOf('/');
-            return projectFilename.substring(0, indexOfLastSlash+1);
+            if (projectFilename != null) {
+                var indexOfLastSlash = projectFilename.lastIndexOf('/');
+                return projectFilename.substring(0, indexOfLastSlash + 1);
+            }
+            return null;
         })
     }
 

--- a/dahu/core/app/scripts/models/objects/background.js
+++ b/dahu/core/app/scripts/models/objects/background.js
@@ -5,17 +5,21 @@
 define([
     'underscore',
     'backbone',
-    'models/object'
-], function(_, Backbone, ObjectModel){
+    'models/object',
+    'uuid'
+], function(_, Backbone, ObjectModel, UUID){
 
     /**
      *  Model of background object
      */
     var BackgroundModel = ObjectModel.extend({
-        defaults: {
-            type: 'background',
-            img: null
-        },
+        defaults: function() {
+            return {
+                id: UUID.v4(),
+                type: 'background',
+                img: null
+            }
+        }
 
     });
 

--- a/dahu/core/app/scripts/modules/utils/paths.js
+++ b/dahu/core/app/scripts/modules/utils/paths.js
@@ -42,8 +42,26 @@ define([
         return join(['dahufile:', dir, img]);
     }
 
+    /**
+     * Gets the full path of the img directory of the current project
+     */
+    function getProjectImgDirectory() {
+        var dir = ReqResponse.request("app:projectDirectory");
+        return join([dir, 'img']);
+    }
+
+    /**
+     * Gets the relative path of the img file of the current project
+     * i.e : 'img/nameOfImg.extension'
+     */
+    function getRelativeImgPath(img) {
+        return join(['img', img]);
+    }
+
     return {
         join: join,
-        getImgFullPath: getImgFullPath
+        getImgFullPath: getImgFullPath,
+        getProjectImgDirectory: getProjectImgDirectory,
+        getRelativeImgPath: getRelativeImgPath
     };
 });

--- a/dahu/core/app/scripts/modules/utils/paths.js
+++ b/dahu/core/app/scripts/modules/utils/paths.js
@@ -3,8 +3,9 @@
  */
 
 define([
-    'underscore'
-], function(_){
+    'underscore',
+    'modules/requestResponse'
+], function(_, ReqResponse){
 
     /**
      * Join one or more path components intelligently.

--- a/dahu/editor/src/main/java/io/dahuapp/editor/kernel/module/Keyboard.java
+++ b/dahu/editor/src/main/java/io/dahuapp/editor/kernel/module/Keyboard.java
@@ -113,13 +113,17 @@ public class Keyboard implements Module {
         }
     }
 
-    @Override
-    public void load() {
-       KeyboardDriver.onLoad();
+    /* Keyboard must not be loaded in load() because
+     * it causes pthread_mutex_lock on Linux
+     * We start it and stop it when we need it
+     * e.g. when switching on Capture Mode
+     */
+
+    public void start(){
+        KeyboardDriver.onLoad();
     }
 
-    @Override
-    public void unload() {
+    public void stop() {
         KeyboardDriver.onUnload();
     }
 }


### PR DESCRIPTION
The keyboard kernel is now loaded when switching on Capture Mode and unloaded when switching off Capture Mode by calling respectively the methods start() and stop()
