### PR TITLE
Add an id generator to the tooltip model

### DIFF
--- a/dahu/core/app/scripts/models/objects/tooltip.js
+++ b/dahu/core/app/scripts/models/objects/tooltip.js
@@ -5,20 +5,24 @@
 define([
     'underscore',
     'backbone',
-    'models/object'
-], function(_, Backbone, ObjectModel){
+    'models/object',
+    'uuid'
+], function(_, Backbone, ObjectModel, UUID){
 
     /**
      *  Model of tooltip object
      */
     var TooltipModel = ObjectModel.extend({
-        defaults: {
-            type: 'tooltip',
-            text: "",
-            color: "#FFFFDD",
-            width: "240px",
-            posx: 0.3,
-            posy: 0.3
+        defaults: function(){
+            return {
+                id: UUID.v4(),
+                type: 'tooltip',
+                text: "",
+                color: "#FFFFDD",
+                width: "240px",
+                posx: 0.3,
+                posy: 0.3
+            }
         },
 
         modifyText: function(newText) {


### PR DESCRIPTION
This is used to get a correct model of tooltips,
as we don't get the id of the parent class here,
we generate here.

Also, when we don't have a correct model, the
view of the tooltips in all wrong.
