### PR TITLE
Properly download and load fit.js

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -50,7 +50,7 @@ require.config({
         bootstrap: '../components/sass-bootstrap/dist/js/bootstrap',
         handlebars: '../components/handlebars/handlebars.amd',
         uuid: '../components/node-uuid/uuid',
-        fit: '../components/fit.js/fit'
+        fit: '../components/fit/lib/fit'
     }
 });
 

--- a/dahu/core/bower.json
+++ b/dahu/core/bower.json
@@ -18,7 +18,8 @@
     "summernote": "~0.5.1",
     "deck.js": "~1.1.0",
     "jqueryui": "~1.10.4",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "fit": "~0.1.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Is this the right fix?

Without this patch, I'm getting:

Error: ENOENT, no such file or directory '/net/anie/local/moy/dev/dahu-next/dahu/core/app/components/fit.js'
In module tree:
    dahuapp
      controller/workspaceLayout
        views/workspace/screen

Adding fit to bower.json ensures that the dependancy is downloaded, but
the path in dahuapp.js was wrong, so fix it too.
