### PR TITLE
Corrected presentation generation

### DIFF
--- a/dahu/common/src/main/java/io/dahuapp/common/kernel/module/DefaultFileSystem.java
+++ b/dahu/common/src/main/java/io/dahuapp/common/kernel/module/DefaultFileSystem.java
@@ -67,7 +67,7 @@ public class DefaultFileSystem implements Module {
                 String resourceName = resourceURL.getPath().startsWith("/") ? resourceURL.getPath().substring(1) : resourceURL.getPath();
                 String targetPath = Paths.get(
                         target,
-                        Paths.get(resource).getFileName().toString()).toString();
+                        Paths.get(resourceName).getFileName().toString()).toString();
 
                 // copy the resource *resourceName* from *jarFilePath* to *targetPath*.
                 return FileSystemDriver.copyResourceDir(jarFilePath, resourceName, targetPath);

--- a/dahu/core/app/scripts/modules/screencast.js
+++ b/dahu/core/app/scripts/modules/screencast.js
@@ -141,7 +141,7 @@ define([
             Kernel.console.info("Copying images");
             //// copy the image folder to the build/img
             Kernel.module('filesystem').copyDir(
-                this.getImagesDirectoryAbsPath, // origin
+                this.getImagesDirectoryAbsPath(), // origin
                 Paths.join([this.getBuildDirectoryAbsPath(), IMAGES_DIRECTORY_NAME]) // destination
             );
             //// copy the cursor


### PR DESCRIPTION
Copying of various resources into the build directory of any given dahu presentation was not working : see #123 and #129 
