### PR TITLE
Adding the 'kind' property to captures + precision on the 'New' window + non-GNOME previews

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -250,7 +250,7 @@ define('dahuapp', [
      */
     function createScreencast() {
         // ask user for project destination
-        var projectDirectoryName = Kernel.module('filesystem').getDirectoryFromUser("Open Dahu Project");
+        var projectDirectoryName = Kernel.module('filesystem').getDirectoryFromUser("Select the directory to store the new Dahu Project");
 
         // return if no given
         if( projectDirectoryName == null ) {

--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -345,6 +345,7 @@ define('dahuapp', [
         var capture = Kernel.module('media').takeCapture(imgDir, image.get('id'));
         // set the img path in image
         image.set('img', screencastController.screencast.getImageRelPathFor(capture.screen));
+        image.set('kind', 'background');
         // set the coordinates of the mouse cursor
         mouse.set('posx', capture.getMouseX());
         mouse.set('posy', capture.getMouseY());

--- a/dahu/editor/src/main/java/io/dahuapp/editor/kernel/module/Browser.java
+++ b/dahu/editor/src/main/java/io/dahuapp/editor/kernel/module/Browser.java
@@ -57,9 +57,7 @@ public class Browser implements Module {
     private void openWebBrowser(String url) {
         if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
             try {
-                LoggerDriver.info("Navigateur OK ?");
                 Desktop.getDesktop().browse(new URL(url).toURI());
-                LoggerDriver.info("Navigateur OK...");
             } catch (URISyntaxException | IOException e) {
                 LoggerDriver.error("Browser (with 'java.awt.Desktop') couldn't be opened.", e);
             } catch (Exception e) {


### PR DESCRIPTION
Issue #119 stated that a "kind" property for every slide was missing ; this is now fixed by adding a "background" value to this property when taking a capture.

Also, the title of the file chooser window when choosing "New" was unclear, it now clearly states that you have to select a directory where the project will be saved (this causes for exemple a misunderstanding leading to issue #121).
