### PR TITLE
Correction of the template presentation.html

### DIFF
--- a/dahu/common/src/main/java/io/dahuapp/common/kernel/module/DefaultFileSystem.java
+++ b/dahu/common/src/main/java/io/dahuapp/common/kernel/module/DefaultFileSystem.java
@@ -67,7 +67,7 @@ public class DefaultFileSystem implements Module {
                 String resourceName = resourceURL.getPath().startsWith("/") ? resourceURL.getPath().substring(1) : resourceURL.getPath();
                 String targetPath = Paths.get(
                         target,
-                        Paths.get(resource).getFileName().toString()).toString();
+                        Paths.get(resourceName).getFileName().toString()).toString();
 
                 // copy the resource *resourceName* from *jarFilePath* to *targetPath*.
                 return FileSystemDriver.copyResourceDir(jarFilePath, resourceName, targetPath);

--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -57,7 +57,7 @@ require.config({
 // Define patcher
 define('patcher', [
     'modules/patches/backbone',
-    'modules/patches/backbone.marionette'
+    'modules/patches/backbone.marionette',
 ], function(
     Backbone, Marionette
 ) {
@@ -85,6 +85,7 @@ define('dahuapp', [
     'modules/commands',
     'modules/requestResponse',
     'modules/utils/paths',
+    'modules/utils/exceptions',
     // controllers
     'controller/screencast',
     'controller/layout',
@@ -99,7 +100,7 @@ define('dahuapp', [
 ], function(
     Patcher,
     $, _, Backbone, Marionette, Handlebars,
-    Kernel, Screencast, events, commands, reqResponse, Paths,
+    Kernel, Screencast, events, commands, reqResponse, Paths, Exceptions,
     ScreencastController, LayoutController,
     ScreencastModel, ScreenModel, ImageModel, MouseModel, TooltipModel,
     ScreensCollection) {
@@ -187,6 +188,13 @@ define('dahuapp', [
         });
         commands.setHandler('app:onCaptureStop', function() {
             captureStop();
+        });
+        commands.setHandler('app:openTipsOfTheDay', function() {
+            throw new Exceptions.NotImplementedError("There are no tips of the day yet.");
+        });
+        commands.setHandler('app:submitFeedback', function() {
+            // TODO : issue #139 : store this URL in the configuration file
+            Kernel.module('browser').openURL("https://github.com/dahuapp/dahu/issues");
         });
     }
 

--- a/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
+++ b/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
@@ -23,29 +23,30 @@
 
         <!-- Required Modernizr file -->
         <script src="./libs/deck.js/modernizr.custom.js"></script>
+        
+        <style>
+            /* temporary */
+            img.background {
+                position: absolute;
+                left: 0px;
+                top: 0px;
+            }
+
+            .tooltip {
+                display: block;
+                position: absolute;
+                padding: 4px;
+                margin: 2px;
+                border: 2px black solid;
+                font-size: 14px;
+            }
+
+            .mouse{
+                position: absolute;
+                width: 15px;
+            }
+        </style>
     </head>
-    <style>
-        /* temporary */
-        img.background {
-            position: absolute;
-            left: 0px;
-            top: 0px;
-        }
-
-        .tooltip {
-            display: block;
-            position: absolute;
-            padding: 4px;
-            margin: 2px;
-            border: 2px black solid;
-            font-size: 14px;
-        }
-
-        .mouse{
-            position: absolute;
-            width: 15px;
-        }
-    </style>
     <body>
     <div class="deck-container">
         <div id="myPresentation">

--- a/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
+++ b/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
@@ -49,31 +49,34 @@
     <body>
     <div class="deck-container">
         <div id="myPresentation">
-            <!-- iterate on all the screens -->
-            <section class="slide">
-            </section>
-            {{#each this.screencast.attributes.screens.models}}
-            <section class="slide" id="screen_{{id}}">
-                <!-- iterate on all objects, show only images -->
-                {{#each attributes.objects.models}}
-                {{#if isImage }}
-                <img src="{{attributes.img}}" class="background" style="width:{{screencastWidth}}; height:{{screencastHeight}};">
-                {{/if}}
-                {{#if isTooltip }}
-                <div class="slide">
-                    <div class="tooltip"
-                         style="background-color: {{attributes.color}}; width: {{attributes.width}}; top:{{normalizedToPixel (screencastHeight) attributes.posy}}; left: {{normalizedToPixel (screencastWidth) attributes.posx}};">
-                        {{{attributes.text}}}
+            {{#if this.screencast.attributes.screens.models}}
+                <!-- iterate on all the screens -->
+                {{#each this.screencast.attributes.screens.models}}
+                <section class="slide" id="screen_{{id}}">
+                    <!-- iterate on all objects, show only images -->
+                    {{#each attributes.objects.models}}
+                    {{#if isImage }}
+                    <img src="{{attributes.img}}" class="background" style="width:{{screencastWidth}}; height:{{screencastHeight}};">
+                    {{/if}}
+                    {{#if isTooltip }}
+                    <div class="slide">
+                        <div class="tooltip"
+                             style="background-color: {{attributes.color}}; width: {{attributes.width}}; top:{{normalizedToPixel (screencastHeight) attributes.posy}}; left: {{normalizedToPixel (screencastWidth) attributes.posx}};">
+                            {{{attributes.text}}}
+                        </div>
                     </div>
-                </div>
-                {{/if}}
-                {{#if isMouse}}
-                <img src="./img/cursor.png" class="mouse"
-                     style="top: {{normalizedToPixel (screencastHeight) attributes.posy}}; left:{{normalizedToPixel (screencastWidth) attributes.posx}};">
-                {{/if}}
+                    {{/if}}
+                    {{#if isMouse}}
+                    <img src="./img/cursor.png" class="mouse"
+                         style="top: {{normalizedToPixel (screencastHeight) attributes.posy}}; left:{{normalizedToPixel (screencastWidth) attributes.posx}};">
+                    {{/if}}
+                    {{/each}}
+                </section>
                 {{/each}}
-            </section>
-            {{/each}}
+            {{else}}
+                <section class="slide">
+                </section>
+            {{/if}}
         </div>
     </div>
     <!-- Required JS files. -->


### PR DESCRIPTION
The empty slide is now only generated when there is no image in the presentation. Otherwise, we iterate on the images like before.

![empty_presentation](https://cloud.githubusercontent.com/assets/12509160/7724904/e48db534-fef5-11e4-90f1-42db3fc3f63d.png)
![not_empty_presentation](https://cloud.githubusercontent.com/assets/12509160/7724932/2081d3ae-fef6-11e4-9056-e5a9cc9f4777.png)

A style tag was not at the right place according to the official definition of HTML. Style is an element of the head tag.
