### PR TITLE
Precision on the 'New' window 

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -250,7 +250,7 @@ define('dahuapp', [
      */
     function createScreencast() {
         // ask user for project destination
-        var projectDirectoryName = Kernel.module('filesystem').getDirectoryFromUser("Open Dahu Project");
+        var projectDirectoryName = Kernel.module('filesystem').getDirectoryFromUser("Select the directory to store the new Dahu Project");
 
         // return if no given
         if( projectDirectoryName == null ) {


### PR DESCRIPTION
The title of the file chooser window when choosing "New" was unclear, it now clearly states that you have to select a directory where the project will be saved (this causes for example a misunderstanding leading to issue #121).
