### PR TITLE
Adding the 'kind' property to captures

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -345,6 +345,7 @@ define('dahuapp', [
         var capture = Kernel.module('media').takeCapture(imgDir, image.get('id'));
         // set the img path in image
         image.set('img', screencastController.screencast.getImageRelPathFor(capture.screen));
+        image.set('kind', 'background');
         // set the coordinates of the mouse cursor
         mouse.set('posx', capture.getMouseX());
         mouse.set('posy', capture.getMouseY());


### PR DESCRIPTION
Issue #119 stated that a "kind" property for every slide was missing ; this is now fixed by adding a "background" value to this property when taking a capture.
