### PR TITLE
Adress #128 - Images metadata have the dimension of the screen. 

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -353,6 +353,12 @@ define('dahuapp', [
         screen.get('objects').add(mouse);
         // Insert the screen in the screencast
         screencastController.screencast.model.addScreen(screen);
+        // Insert the dimension of the screencast 
+        // if it is the first
+        if (screencastController.screencast.model.getScreenWidth() == 0) {
+            screencastController.screencast.model.setScreenWidth(capture.screenSize.getWidth());
+            screencastController.screencast.model.setScreenHeight(capture.screenSize.getHeight());
+        };
         // Refresh the workspace
         onScreenSelect(screen);
     }

--- a/dahu/core/app/scripts/models/screencast.js
+++ b/dahu/core/app/scripts/models/screencast.js
@@ -74,10 +74,26 @@ define([
         },
 
         /**
+         * Set screen width
+         * @param width width of the screen
+         */
+        setScreenWidth: function(width) {
+            this.get('settings').set('screenWidth', width);
+        },
+
+        /**
          * Return the current screencast height.
          */
         getScreenHeight: function() {
             return this.get('settings').get('screenHeight');
+        },
+
+        /**
+         * Set the height of the screen in the settings
+         * @param height height of the screen
+         */
+        setScreenHeight: function(height) {
+            this.get('settings').set('screenHeight', height)
         },
 
         /**

--- a/dahu/core/app/scripts/models/settings.js
+++ b/dahu/core/app/scripts/models/settings.js
@@ -12,8 +12,8 @@ define([
      */
     var SettingsModel = Backbone.Model.extend({
         defaults: {
-            screenWidth: 800,
-            screenHeight: 494 // golden ratio
+            screenWidth: 0,
+            screenHeight: 0 // golden ratio
         }
     });
 


### PR DESCRIPTION
The problem was generated because in .dahu there was default dimension (width and heigth).

We solved it by giving the metadata model the current size of the capture.
The metadata only takes the first size given.
We also needed to put new setters on the screencast to pursue this modification.
