### PR TITLE
Adress #128 : Images metadata have the dimension of the screen

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -354,6 +354,12 @@ define('dahuapp', [
         screen.get('objects').add(mouse);
         // Insert the screen in the screencast
         screencastController.screencast.model.addScreen(screen);
+        // Insert the dimension of the screencast 
+        // if it is the first time in the project
+        if (!(screencastController.screencast.model.hasScreenDimension())) {
+            screencastController.screencast.model.setScreenWidth(capture.screenSize.getWidth());
+            screencastController.screencast.model.setScreenHeight(capture.screenSize.getHeight());
+        };
         // Refresh the workspace
         onScreenSelect(screen);
     }

--- a/dahu/core/app/scripts/models/screencast.js
+++ b/dahu/core/app/scripts/models/screencast.js
@@ -67,6 +67,15 @@ define([
         },
 
         /**
+         *  Check the dimensions in the settings
+         * 
+         * @return {Boolean} true if dimension in settings are defined
+         */
+        hasScreenDimension: function() {
+            return this.get('settings').hasScreenDimension();
+        },
+
+        /**
          * Get screen width
          */
         getScreenWidth: function() {
@@ -74,10 +83,26 @@ define([
         },
 
         /**
+         * Set screen width
+         * @param width width of the screen
+         */
+        setScreenWidth: function(width) {
+            this.get('settings').set('screenWidth', width);
+        },
+
+        /**
          * Return the current screencast height.
          */
         getScreenHeight: function() {
             return this.get('settings').get('screenHeight');
+        },
+
+        /**
+         * Set the height of the screen in the settings
+         * @param height height of the screen
+         */
+        setScreenHeight: function(height) {
+            this.get('settings').set('screenHeight', height)
         },
 
         /**

--- a/dahu/core/app/scripts/models/settings.js
+++ b/dahu/core/app/scripts/models/settings.js
@@ -12,8 +12,18 @@ define([
      */
     var SettingsModel = Backbone.Model.extend({
         defaults: {
-            screenWidth: 800,
-            screenHeight: 494 // golden ratio
+            screenWidth: undefined,
+            screenHeight: undefined
+        },
+
+        /**
+         * Predicate to know if the dimensions were 
+         * previously set.
+         * 
+         * @return {Boolean} true if both screenWidth and screenHeigh are defined
+         */
+        hasScreenDimension: function() {
+            return !((this.screenWidth === undefined) || (this.screenHeight === undefined));
         }
     });
 


### PR DESCRIPTION
Set default dimension of settings model to undefined.
New function screencast.hasDimension to test if dimension
had been set.
dahuapp check if screencast has dimension, so it set them
once in a project.
