### PR TITLE
Correction issue#133

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -157,6 +157,16 @@ define('dahuapp', [
         events.on('app:workspace:tooltips:edit', function(tooltip) {
             onTooltipEdit(tooltip);
         });
+        events.on('app:onPreview', function() {
+            previewScreencast();
+        });
+        events.on('app:activateFullscreenMode', function() {
+            Kernel.module('contextmanager').fullScreen();
+        });
+        events.on('app:openPropertyPane', function() {
+            // TODO : implement the configuration menu for the meta-data of the screencast
+            throw new Exceptions.NotImplementedError("There is no configuration menu for the meta-data of the screencast yet.");
+        });
     }
 
     /**

--- a/dahu/core/app/scripts/modules/kernel/SCI.js
+++ b/dahu/core/app/scripts/modules/kernel/SCI.js
@@ -19,8 +19,9 @@ define([
     'modules/kernel/filesystem',
     'modules/kernel/media',
     'modules/kernel/keyboard',
-    'modules/kernel/browser'
-], function(_, Backbone, Console, Filesystem, Media, Keyboard, Browser) {
+    'modules/kernel/browser',
+    'modules/kernel/contextmanager'
+], function(_, Backbone, Console, Filesystem, Media, Keyboard, Browser, ContextManager) {
 
     var self = {};
 
@@ -51,6 +52,7 @@ define([
             expose('media', Media);
             expose('keyboard', Keyboard);
             expose('browser', Browser);
+            expose('contextmanager', ContextManager);
         } else {
             // we do not have an existing kernel
             // this case happen when we are running
@@ -61,6 +63,7 @@ define([
             expose('media', Media);
             expose('keyboard', Keyboard); // fallback Keyboard
             expose('browser', Browser);
+            expose('contextmanager', ContextManager);
         }
 
         // console is mandatory

--- a/dahu/core/app/scripts/modules/kernel/contextmanager.js
+++ b/dahu/core/app/scripts/modules/kernel/contextmanager.js
@@ -1,0 +1,32 @@
+/**
+ * Created by coutinju on 21/05/15.
+ */
+
+define([], function() {
+
+    var self;
+
+    var fallback = {
+        // here we must define some basic
+        // implementation of the contextmanager
+        // for debugging only
+    }
+
+    // singleton
+
+    function instance() {
+        if(typeof(self) === 'undefined') {
+            if(typeof(kernel) != "undefined" && typeof(kernel.contextmanager) != "undefined") {
+                self = kernel.contextmanager;
+            } else {
+                self = fallback;
+            }
+        }
+
+        return self
+    }
+
+    return {
+        instance: instance
+    }
+});

--- a/dahu/editor/src/main/java/io/dahuapp/editor/kernel/DahuAppKernel.java
+++ b/dahu/editor/src/main/java/io/dahuapp/editor/kernel/DahuAppKernel.java
@@ -20,6 +20,7 @@ public class DahuAppKernel implements Kernel {
     public FileSystem filesystem;
     public Keyboard keyboard;
     public Browser browser;
+    public ContextManager contextmanager;
 
     // shared objects
     private Stage primaryStage;
@@ -34,6 +35,7 @@ public class DahuAppKernel implements Kernel {
         keyboard = new Keyboard(webEngineRuntime);
         filesystem = new FileSystem(primaryStage, fileAccessManager, rewriter);
         browser = new Browser();
+        contextmanager = new ContextManager(stage);
     }
 
     @Override
@@ -43,6 +45,7 @@ public class DahuAppKernel implements Kernel {
         media.load();
         keyboard.load();
         browser.load();
+        contextmanager.load();
         // done loading
         console.info("Dahuapp kernel started!");
     }
@@ -57,6 +60,7 @@ public class DahuAppKernel implements Kernel {
         browser.unload();
         console.unload();
         browser.unload();
+        contextmanager.unload();
         // exit app
         Platform.exit();
     }

--- a/dahu/editor/src/main/java/io/dahuapp/editor/kernel/module/ContextManager.java
+++ b/dahu/editor/src/main/java/io/dahuapp/editor/kernel/module/ContextManager.java
@@ -1,0 +1,35 @@
+package io.dahuapp.editor.kernel.module;
+
+import io.dahuapp.common.kernel.Module;
+import javafx.stage.Stage;
+
+/** 
+ * ContextManager kernel module.
+ * 
+ * Used to interact with the JavaFX application containing the web view.
+ * @author coutinju
+ */
+public class ContextManager implements Module {
+    /**
+     * Stage of the javaFX application containing the web view
+     */
+    private Stage primaryStage;
+    
+    /**
+     * 
+     * @param primaryStage Stage of the JavaFX application containing the web view.
+     */
+    public ContextManager(Stage primaryStage) {
+        this.primaryStage = primaryStage;
+    }
+    
+    /**
+     * Enable or disable full screen.
+     * If the screen if already on fullscreen it is minimized.
+     * Otherwise, it is maximized.
+     */
+    public void fullScreen() {
+        boolean maximized = this.primaryStage.isMaximized();
+        this.primaryStage.setMaximized(!maximized);
+    }
+}


### PR DESCRIPTION
Depends on pull request #153.

Implementing the actions when clicking on the buttons of the webview.
The fullscreen button calls the editor setMaximized to true or false,
depending on its previous value.
The preview button in the interface has the same action as the button in the
editor (previewScreencast).
The configuration menu for the screencast is not implemented yet : throws error
