### PR TITLE
Adressing issue #133

### DIFF
--- a/dahu/core/app/scripts/dahuapp.js
+++ b/dahu/core/app/scripts/dahuapp.js
@@ -157,6 +157,16 @@ define('dahuapp', [
         events.on('app:workspace:tooltips:edit', function(tooltip) {
             onTooltipEdit(tooltip);
         });
+        events.on('app:onPreview', function() {
+            previewScreencast();
+        });
+        events.on('app:activateFullscreenMode', function() {
+            Kernel.module('contextmanager').fullScreen();
+        });
+        events.on('app:openPropertyPane', function() {
+            // TODO : implement the configuration menu for the meta-data of the screencast
+            throw new Exceptions.NotImplementedError("There is no configuration menu for the meta-data of the screencast yet.");
+        });
     }
 
     /**


### PR DESCRIPTION
Implementing the actions when clicking on the buttons of the webview.
The fullscreen button calls the editor setMaximized to true or false,
depending on its previous value.
The preview button in the interface has the same action as the button in the
editor (previewScreencast).
The configuration menu for the screencast is not implemented yet : throws error
