### PR TITLE
Resolve #152 by disabling screencast menus

### DIFF
--- a/dahu/core/app/scripts/controller/screencast.js
+++ b/dahu/core/app/scripts/controller/screencast.js
@@ -34,7 +34,9 @@ define([
                 this.screencast = Screencast.load(projectFilename);
                 this._registerToGlobalEvents();
                 this._registerToCommands();
+                Kernel.module('contextmanager').setDisableScreencastMenus(false);
             } catch(e) {
+                Kernel.module('contextmanager').setDisableScreencastMenus(true);
                 Kernel.console.error(e);
                 this.screencast = null;
             }
@@ -54,8 +56,10 @@ define([
                 this.screencast = Screencast.create(projectFilename);
                 this._registerToGlobalEvents();
                 this._registerToCommands();
+                Kernel.module('contextmanager').setDisableScreencastMenus(false);
             } catch(e) {
                 Kernel.console.error(e);
+                Kernel.module('contextmanager').setDisableScreencastMenus(true);
                 this.screencast = null;
             }
         },

--- a/dahu/editor/src/main/java/io/dahuapp/editor/DahuApp.java
+++ b/dahu/editor/src/main/java/io/dahuapp/editor/DahuApp.java
@@ -44,6 +44,11 @@ public class DahuApp extends Application {
      * Minimum height of the editor window.
      */
     private static final int MIN_HEIGHT = 520;
+    /**
+     * ID Values for menu elements subject to changes
+     */
+    public static final String CAPTURE_MENU_ID = "menuCapture";
+    public static final String GENERATION_MENU_ID = "menuGeneration";
 
     /**
      * Application components
@@ -259,6 +264,11 @@ public class DahuApp extends Application {
 
         menuHelp.getItems().addAll(menuHelpTips, new SeparatorMenuItem(), menuHelpFeedback);
         
+        menuCapture.setDisable(true);
+        menuCapture.setId(CAPTURE_MENU_ID);
+        menuGeneration.setDisable(true);
+        menuGeneration.setId(GENERATION_MENU_ID);
+
         // Create the main menu bar
         menuBar = new MenuBar();
         menuBar.getMenus().addAll(menuFile, menuCapture, menuGeneration, menuHelp);

--- a/dahu/editor/src/main/java/io/dahuapp/editor/kernel/module/ContextManager.java
+++ b/dahu/editor/src/main/java/io/dahuapp/editor/kernel/module/ContextManager.java
@@ -1,6 +1,9 @@
 package io.dahuapp.editor.kernel.module;
 
 import io.dahuapp.common.kernel.Module;
+import io.dahuapp.editor.DahuApp;
+import javafx.scene.control.MenuBar;
+import javafx.scene.layout.BorderPane;
 import javafx.stage.Stage;
 
 /** 
@@ -14,6 +17,7 @@ public class ContextManager implements Module {
      * Stage of the javaFX application containing the web view
      */
     private Stage primaryStage;
+    private MenuBar menuBar;
     
     /**
      * 
@@ -31,5 +35,14 @@ public class ContextManager implements Module {
     public void fullScreen() {
         boolean maximized = this.primaryStage.isMaximized();
         this.primaryStage.setMaximized(!maximized);
+    }
+
+    /**
+     * Enable the menu items regarding the screencasting options (start/stop, generate, ...)
+     * This will be called after a presentation has been opened.
+     */
+    public void setDisableScreencastMenus(boolean val) {
+        this.primaryStage.getScene().lookup("#"+DahuApp.CAPTURE_MENU_ID).setDisable(val);
+        this.primaryStage.getScene().lookup("#"+DahuApp.GENERATION_MENU_ID).setDisable(val);
     }
 }


### PR DESCRIPTION
The screencast option menus were enabled by default, whether a
presentation was created, loaded or not. Now, they are disabled by
default and enabled after loading or a creating a Dahu presentation,
preventing any issue that would happen when using a screencasting option
while no presentation is currently active.
