### PR TITLE
Display existings action in the editor

### DIFF
--- a/dahu/core/app/scripts/templates/views/workspace/actions.html
+++ b/dahu/core/app/scripts/templates/views/workspace/actions.html
@@ -1,2 +1,3 @@
-<div id="myActions">
-</div>
+<!--	
+	Empty on purpose
+-->

--- a/dahu/core/app/scripts/templates/views/workspace/actions/action.html
+++ b/dahu/core/app/scripts/templates/views/workspace/actions/action.html
@@ -1,0 +1,5 @@
+<ul>
+	<li><strong>{{type}}</strong></li>
+	<li>Target : {{target}}</li>
+	<li>Trigger : {{trigger}}</li>
+</ul>

--- a/dahu/core/app/scripts/views/workspace/actions.js
+++ b/dahu/core/app/scripts/views/workspace/actions.js
@@ -13,6 +13,7 @@ define([
     'views/workspace/actions/appear',
     'views/workspace/actions/disappear',
     'views/workspace/actions/move',
+    'views/workspace/actions/action',
     // templates
     'text!templates/views/workspace/actions.html'
 ], function(
@@ -26,17 +27,19 @@ define([
     AppearView,
     DisappearView,
     MoveView,
+    ActionView,
     // templates
-    actionTemplates){
+    actionsTemplate
+) {
 
     /**
      * Workspace actions view
      */
     return Marionette.CompositeView.extend({
 
-        template: Handlebars.default.compile(actionTemplates),
+        template: Handlebars.default.compile(actionsTemplate),
 
-        childViewContainer: '#myActions',
+        className: "ActionsList",
 
         initialize : function (options) {
             // mandatory arguments
@@ -59,15 +62,8 @@ define([
             }*/
         },
 
-        // We select the ItemView depending on the object type.
         getChildView: function(item){
-            if(item instanceof AppearModel) {
-                return AppearView;
-            }else if(item instanceof DisappearModel){
-                return DisappearView;
-            }else if(item instanceof MoveModel){
-                return MoveView;
-            }
+            return ActionView;
         },
 
         onChanged: function(){

--- a/dahu/core/app/scripts/views/workspace/actions/action.js
+++ b/dahu/core/app/scripts/views/workspace/actions/action.js
@@ -1,23 +1,23 @@
 /**
- * Created by nabilbenabbou1 on 6/13/14.
+ * Created by obzota on 28/5/15.
  */
 
 define([
     'handlebars',
     'backbone.marionette',
     // templates
-    'text!templates/views/workspace/actions/appear.html'
+    'text!templates/views/workspace/actions/action.html'
 ], function(
     Handlebars,
     Marionette,
     // templates
-    appearTemplate
+    actionTemplate
 ) {
     
     /**
-     * Appear action view
+     * Generic action view
      */
     return Marionette.ItemView.extend({
-        template: Handlebars.default.compile(appearTemplate)
+        template: Handlebars.default.compile(actionTemplate)
     });
 });

--- a/dahu/core/app/scripts/views/workspace/actions/disappear.js
+++ b/dahu/core/app/scripts/views/workspace/actions/disappear.js
@@ -11,8 +11,9 @@ define([
     Handlebars,
     Marionette,
     // templates
-    disappearTemplate){
-
+    disappearTemplate
+) {
+    
     /**
      * Disappear action view
      */

--- a/dahu/core/app/scripts/views/workspace/actions/move.js
+++ b/dahu/core/app/scripts/views/workspace/actions/move.js
@@ -11,8 +11,9 @@ define([
     Handlebars,
     Marionette,
     // templates
-    moveTemplate){
-
+    moveTemplate
+) {
+    
     /**
      * Move action view
      */

--- a/dahu/core/app/styles/main.scss
+++ b/dahu/core/app/styles/main.scss
@@ -81,7 +81,7 @@ html, body {
     position: absolute;
     height: 220px;
     left: 0px;
-    right: 0px;
+    right: 220px;
     bottom: 0px;
     border-top: 5px solid #e5e5e5;
   }


### PR DESCRIPTION
Editor display actions existing on each screen

Openning an ancient dahu project including actions will allow the displaying of those actions.
Adding or modifying tools not yet implemented.

Add : 
- Generic View Action 
- Template for Action

Modify : 
- template actions : handlebars already generate a div
- actions : Use generic view for displaying the action collection (getChildView). Specify a className for the handlebar generated <div>.
- move, appear & disappear : uniformisation
- main.scss : constrain dimensions of the note textarea in order to display full action list. 
