### PR TITLE
Introduce support for note edition and preview

### DIFF
--- a/dahu/core/Gruntfile.js
+++ b/dahu/core/Gruntfile.js
@@ -345,6 +345,12 @@ module.exports = function (grunt) {
             },
             deckjs: {
                 files: [{
+                    // copy notes extension into the extensions directory of deck.js
+                    expand: true,
+                    cwd: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.ext.js/extensions/notes/',
+                    src: ['**'],
+                    dest: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.js/extensions/notes/'
+                }, {
                     expand: true,
                     cwd: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.js/',
                     src: ['**'],

--- a/dahu/core/app/scripts/controller/layout.js
+++ b/dahu/core/app/scripts/controller/layout.js
@@ -14,12 +14,13 @@ define([
     'views/filmstrip/screens',
     'views/components/main_toolbar',
     'views/components/workspace_toolbar',
+    'views/workspace/note',
     // templates
     'text!templates/modals/tooltip.html'
 ], function (Handlebars, Marionette, // libraries
              Kernel, events, Modals, // modules
              DahuLayout, WorkspaceLayout, // layouts
-             ScreenView, ActionsView, FilmstripScreensView, MainToolbarView, WorkspaceToolbarView, // views
+             ScreenView, ActionsView, FilmstripScreensView, MainToolbarView, WorkspaceToolbarView, NoteView, // views
              tooltipModalTemplate // templates
 ) {
 
@@ -27,7 +28,7 @@ define([
      * Workspace layout controller.
      */
     return Marionette.Controller.extend({
-
+        
         initialize: function(options){
             this.screencast = options.screencast;
         },
@@ -141,6 +142,11 @@ define([
             this._registerToScreenEditorEvents();
 
             this.workspaceLayout.actionsEditor.show(new ActionsView({
+                screencast: this.screencast,
+                screenId: screenId
+            }));
+            
+            this.workspaceLayout.noteEditor.show(new NoteView({
                 screencast: this.screencast,
                 screenId: screenId
             }));

--- a/dahu/core/app/scripts/controller/screencast.js
+++ b/dahu/core/app/scripts/controller/screencast.js
@@ -103,6 +103,8 @@ define([
          */
         save: function() {
             if( this.screencast ) {
+                events.trigger("before:app:screencast:save");
+                events.trigger("app:screencast:save");
                 this.screencast.save();
             } else {
                 throw "No Dahu project loaded."

--- a/dahu/core/app/scripts/layouts/dahuapp.js
+++ b/dahu/core/app/scripts/layouts/dahuapp.js
@@ -20,8 +20,7 @@ define([
         regions: {
             toolbar: "#main-toolbar",
             filmstrip: "#filmstrip",
-            workspace: "#workspace",
-            note: "#note"
+            workspace: "#workspace"
         }
     });
 

--- a/dahu/core/app/scripts/layouts/workspace.js
+++ b/dahu/core/app/scripts/layouts/workspace.js
@@ -6,10 +6,17 @@ define([
     'underscore',
     'handlebars',
     'backbone.marionette',
+    // views
     'views/workspace/screen',
     'views/workspace/actions',
+    'views/workspace/note',
+    // template
     'text!templates/layouts/workspace.html'
-], function(_, Handlebars, Marionette, screenView, actionsView, workspaceTemplate){
+], function(
+    _, Handlebars, Marionette, 
+    screenView, actionsView, noteView, // views
+    workspaceTemplate // template
+) {
 
     /**
      * Dahu workspace layout.

--- a/dahu/core/app/scripts/models/note.js
+++ b/dahu/core/app/scripts/models/note.js
@@ -1,0 +1,24 @@
+/**
+ * Created by reyr on 21/05/2015
+ */
+define([
+	'underscore',
+	'backbone',
+	'uuid'
+], function(_, Backbone, UUID){
+
+	var NoteModel = Backbone.Model.extend({
+		defaults: function () {
+			return {
+				id: UUID.v4(),
+				text: ""
+			};
+		},
+
+		setText: function(newText) {
+                    this.set('text', newText);
+                }
+	});
+
+	return NoteModel;
+});

--- a/dahu/core/app/scripts/models/screen.js
+++ b/dahu/core/app/scripts/models/screen.js
@@ -1,14 +1,16 @@
 define([
+    // librairies
     'underscore',
     'backbone',
     'uuid',
     // models
     'models/objects/tooltip',
+    'models/note',
     // collections
     'collections/objects',
     'collections/actions'
 ], function(_, Backbone, UUID, // libraries
-            TooltipModel, // models
+            TooltipModel, NoteModel,// models
             ObjectCollection, ActionsCollection // collections
 ){
 
@@ -20,8 +22,9 @@ define([
             return {
                 id: UUID.v4(),
                 objects: new ObjectCollection(),
-                actions : new ActionsCollection()
-            }
+                actions : new ActionsCollection(),
+                note : new NoteModel()
+            };
         },
 
         initialize: function () {
@@ -32,6 +35,9 @@ define([
             // wrap up actions around ActionsCollection unless it already is
             if ( ! (this.get('actions') instanceof ActionsCollection) ) {
                 this.set('actions', new ActionsCollection(this.get('actions')));
+            }
+            if ( ! (this.get('note') instanceof NoteModel) ) {
+                this.set('note', new NoteModel(this.get('note')));
             }
         },
 

--- a/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
+++ b/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
@@ -11,6 +11,7 @@
         <link rel="stylesheet" media="screen" href="./libs/deck.js/extensions/navigation/deck.navigation.css">
         <link rel="stylesheet" media="screen" href="./libs/deck.js/extensions/status/deck.status.css">
         <link rel="stylesheet" media="screen" href="./libs/deck.js/extensions/scale/deck.scale.css">
+        <link rel="stylesheet" media="screen" href="./libs/deck.js/extensions/notes/deck.notes.css">
 
         <!-- Style theme. More available in /themes/style/ or create your own. -->
         <link rel="stylesheet" media="screen" href="./libs/deck.js/themes/style/web-2.0.css">
@@ -31,7 +32,6 @@
                 left: 0px;
                 top: 0px;
             }
-
             .tooltip {
                 display: block;
                 position: absolute;
@@ -40,7 +40,6 @@
                 border: 2px black solid;
                 font-size: 14px;
             }
-
             .mouse{
                 position: absolute;
                 width: 15px;
@@ -53,25 +52,29 @@
             {{#if this.screencast.attributes.screens.models}}
                 <!-- iterate on all the screens -->
                 {{#each this.screencast.attributes.screens.models}}
-                <section class="slide" id="screen_{{id}}">
+                <section class="slide" id="screen_{{this.id}}">
                     <!-- iterate on all objects, show only images -->
-                    {{#each attributes.objects.models}}
+                    {{#each this.attributes.objects.models}}
                     {{#if isImage }}
-                    <img src="{{attributes.img}}" class="background" style="width:{{screencastWidth}}; height:{{screencastHeight}};">
+                    <img src="{{this.attributes.img}}" class="background" style="width:{{screencastWidth}}; height:{{screencastHeight}};">
                     {{/if}}
                     {{#if isTooltip }}
                     <div class="slide">
                         <div class="tooltip"
-                             style="background-color: {{attributes.color}}; width: {{attributes.width}}; top:{{normalizedToPixel (screencastHeight) attributes.posy}}; left: {{normalizedToPixel (screencastWidth) attributes.posx}};">
-                            {{{attributes.text}}}
+                             style="background-color: {{this.attributes.color}}; width: {{this.attributes.width}}; top:{{normalizedToPixel (screencastHeight) this.attributes.posy}}; left: {{normalizedToPixel (screencastWidth) this.attributes.posx}};">
+                            {{this.attributes.text}}
                         </div>
                     </div>
                     {{/if}}
                     {{#if isMouse}}
                     <img src="./img/cursor.png" class="mouse"
-                         style="top: {{normalizedToPixel (screencastHeight) attributes.posy}}; left:{{normalizedToPixel (screencastWidth) attributes.posx}};">
+                         style="top: {{normalizedToPixel (screencastHeight) this.attributes.posy}}; left:{{normalizedToPixel (screencastWidth) this.attributes.posx}};">
                     {{/if}}
                     {{/each}}
+                    {{#if this.attributes.note}}
+                    <div class="deck-notes" style="white-space: pre;">{{this.attributes.note.attributes.text}}
+                    </div>
+                    {{/if}}
                 </section>
                 {{/each}}
             {{else}}
@@ -90,6 +93,7 @@
     <script src="./libs/deck.js/extensions/status/deck.status.js"></script>
     <script src="./libs/deck.js/extensions/navigation/deck.navigation.js"></script>
     <script src="./libs/deck.js/extensions/scale/deck.scale.js"></script>
+    <script src="./libs/deck.js/extensions/notes/deck.notes.js"></script>
 
     <!-- Initialize the deck. You can put this in an external file if desired. -->
     <script>

--- a/dahu/core/app/scripts/templates/views/workspace/note.html
+++ b/dahu/core/app/scripts/templates/views/workspace/note.html
@@ -1,0 +1,1 @@
+<textarea name="note" id="note_textarea">{{text}}</textarea>

--- a/dahu/core/app/scripts/views/workspace/note.js
+++ b/dahu/core/app/scripts/views/workspace/note.js
@@ -1,0 +1,49 @@
+/**
+ * Created by obzota on 22/05/15.
+ */
+
+define([
+    'handlebars',
+    'backbone.marionette',
+    // modules
+    'modules/events',
+    // templates
+    'text!templates/views/workspace/note.html'
+], function(
+    Handlebars,
+    Marionette,
+    // modules
+    events,
+    // templates
+    noteTemplate){
+
+    /**
+     * Note screen view
+     */
+    return Marionette.ItemView.extend({
+        template: Handlebars.default.compile(noteTemplate),
+        className: 'note',
+
+        events: {
+            "focusout" : "updateNoteModel"
+        },
+
+        initialize: function (options) {
+            var self = this;
+            _.extend(this, _.pick(options, ['screencast', 'screenId']));
+            this.model = this.screencast.model.getScreenById(this.screenId).get('note');
+            events.on("before:app:screencast:save", function() {
+                self.updateNoteModel();
+            });
+        },
+
+        updateNoteModel: function () {
+            this.model.setText($("#note_textarea").val());
+        },
+        
+        onDestroy: function () {
+            events.off("app:screencast:save");
+        }
+
+    });
+});

--- a/dahu/core/app/styles/main.scss
+++ b/dahu/core/app/styles/main.scss
@@ -84,6 +84,17 @@ html, body {
     right: 0px;
     bottom: 0px;
     border-top: 5px solid #e5e5e5;
+    width: 100%;
+    
+    .note {
+      width: 100%;
+      height: 100%;
+      
+      #note_textarea {
+        width: 100%;
+        height: 100%;
+      }
+    }
   }
 }
 

--- a/dahu/core/bower.json
+++ b/dahu/core/bower.json
@@ -21,7 +21,8 @@
     "fit.js": "*",
     "bootstrap-sass": "~3.3.4",
     "bootstrap": "~3.3.4",
-    "font-awesome": ">=4.2.0"
+    "font-awesome": ">=4.2.0",
+    "deck.ext.js": "~0.1.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Insert the possibility of adding notes
to the presentation. In the editor, a textarea
can be filled with a text for each screen of the
current screencast. Those notes can be read in
the preview with a pluggin that can display/hide.

Edition and Preview :

After taking a screenshot, the creator can select the screenshot to which he 
wants to add a note by clicking on it. When the screen is selected, the 
workspace displays the screenshot and under it there is a note area in which the 
creator can write the note concerning the selected screenshot. When ths note 
area loses the focus, its content is saved in the model but note in the ".dahu" 
file. To save his notes, the user must click on the "save" menu item in the 
"file" menu in the toolbar. At that moment the note is saved in the ".dahu" file
 and when the presentation is generated, the notes saved will present in the 
presentation. 

During a presentation, to display a note, the user can display a note by 
pressing the key "n" when he is on the slide which contains a note. Warning, the
notes are displayed only if the user uses chrome (no support on mozilla).

Added :
- a 'note model'
- a 'note layout'
- a 'note view'

Note model only contains a single text and an Id (for
the DOM). Note View catches events related to changing
screen and saving, in order to load and save the notes.
Currently the note is saved on the textarea 'focusout'
and on the action save in the menu (wich doesn't
trigger 'focusout').

Modification :
- bower.json : add dependencies to make the
  pluggin note work with deckJS
- Gruntfile.js : allow the copy of deck.js
  files to the right location
- Screen Model : include a 'note' attribute
- Dahuapp
- Layout Workspace : add a note region to the
  layout.
