### PR TITLE
Automatic resize of slides using fit.js

### DIFF
--- a/dahu/core/Gruntfile.js
+++ b/dahu/core/Gruntfile.js
@@ -350,6 +350,14 @@ module.exports = function (grunt) {
                     src: ['**'],
                     dest: '<%= yeoman.dist %>/<%= yeoman.bower %>/deck.js/'
                 }]
+            },
+            fitjs: {
+                files: [{
+                    expand: true,
+                    cwd: '<%= yeoman.app %>/<%= yeoman.bower %>/fit.js/',
+                    src: ['**'],
+                    dest: '<%= yeoman.dist %>/<%= yeoman.bower %>/fit.js/'
+                }]
             }
         },
         // Remove logging from generated files.

--- a/dahu/core/app/scripts/modules/screencast.js
+++ b/dahu/core/app/scripts/modules/screencast.js
@@ -157,6 +157,11 @@ define([
                 'classpath:///io/dahuapp/core/components/deck.js', // origin
                 Paths.join([this.getBuildDirectoryAbsPath(), LIBRARIES_DIRECTORY_NAME]) // destination
             );
+            //// copy fit.js folder to build/libs/fit.js
+            Kernel.module('filesystem').copyResourceDir(
+                'classpath:///io/dahuapp/core/components/fit.js', // origin
+                Paths.join([this.getBuildDirectoryAbsPath(), LIBRARIES_DIRECTORY_NAME]) // destination
+            );
             Kernel.console.info("done.");
         },
 

--- a/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
+++ b/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
@@ -23,6 +23,7 @@
 
         <!-- Required Modernizr file -->
         <script src="./libs/deck.js/modernizr.custom.js"></script>
+        <script src="./libs/fit.js/fit.js"></script>
         
         <style>
             /* temporary */
@@ -48,7 +49,7 @@
         </style>
     </head>
     <body>
-    <div class="deck-container">
+    <div class="deck-container" style="width: {{screencastWidth}}; height: {{screencastHeight}};">
         <div id="myPresentation">
             {{#if this.screencast.attributes.screens.models}}
                 <!-- iterate on all the screens -->
@@ -95,6 +96,14 @@
     <script>
         $(function () {
             $.deck('.slide');
+            var body = $('body').get(0);
+            var cont = $.deck('getContainer').get(0);			
+            fit(cont, body, {
+                hAlign: fit.CENTER,
+                vAlign: fit.CENTER,
+                watch: true,
+                cover: false
+            });
         });
     </script>
     </body>


### PR DESCRIPTION
When resizing the window of the browser displaying the slides, or when
displaying the sides on a system using a smaller resolution, the slides
were distorted, and did not keep the original picture ratio. This is now
fixed by using the fit.js library for the slides player, now resizing
the slides correctly according to the window size, and placing them in
the center of their container window. Therefore, the HTML template used
by the slides was changed, and the fit.js library is now included as
well with deck.js when the HTML is generated.
