### PR TITLE
Add a trim_trailing_whitespace in editor config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,4 +7,4 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
-
+trim_trailing_whitespace = true


### PR DESCRIPTION
trailing whitespace can cause useless merge conflicts.
This setting help editors cleaning it up via EditorConfig.

More infos (IDE pluggins) at : http://editorconfig.org/#overview
