### PR TITLE
Complete build files to include deck.animator to dahu presentations

### DIFF
--- a/dahu/core/Gruntfile.js
+++ b/dahu/core/Gruntfile.js
@@ -345,6 +345,12 @@ module.exports = function (grunt) {
             },
             deckjs: {
                 files: [{
+                    // copy notes extension into the extensions directory of deck.js
+                    expand: true,
+                    cwd: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.ext.js/extensions/animator/',
+                    src: ['**'],
+                    dest: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.js/extensions/animator/'
+                }, {
                     expand: true,
                     cwd: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.js/',
                     src: ['**'],

--- a/dahu/core/bower.json
+++ b/dahu/core/bower.json
@@ -16,6 +16,7 @@
     "backbone.marionette": "~2.4.1",
     "summernote": "~0.6.6",
     "deck.js": "~1.1.0",
+    "deck.ext.js": "~0.1.1",
     "jqueryui": "~1.10.4",
     "lodash": "~3.8.0",
     "fit.js": "*",


### PR DESCRIPTION
Upon building a presentation, the correct plugin is included in order to be able to play the actions descripted in the project file.
