### PR TITLE
Complete build files and screencast template to use deck.animator

### DIFF
--- a/dahu/core/Gruntfile.js
+++ b/dahu/core/Gruntfile.js
@@ -345,6 +345,12 @@ module.exports = function (grunt) {
             },
             deckjs: {
                 files: [{
+                    // copy animator extension into the extensions directory of deck.js
+                    expand: true,
+                    cwd: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.ext.js/extensions/animator/',
+                    src: ['**'],
+                    dest: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.js/extensions/animator/'
+                }, {
                     expand: true,
                     cwd: '<%= yeoman.app %>/<%= yeoman.bower %>/deck.js/',
                     src: ['**'],

--- a/dahu/core/app/scripts/modules/helpers/template.js
+++ b/dahu/core/app/scripts/modules/helpers/template.js
@@ -61,24 +61,24 @@ define([
         });
         
         /**
-         * Returns a string matching the JSON object of 'element'.
+         * Return a string matching the JSON object of 'element'.
          *
          * @param element Element to turn into a String
          * @param indentNb Number of spaces in an indentation
          * @param initiaIndent Number of indentations to add at the beginning of each line
          * @returns {string} a formatted JSON object as a String.
          */
-        Handlebars.default.registerHelper('dumpJSON', function (element, indentNb, initialIndent) {
+        Handlebars.default.registerHelper('stringify', function (element, indentNb, initialIndent) {
             var res = JSON.stringify(element, null, indentNb);
             res = res.replace(/^/gm, Array(initialIndent*indentNb+1).join(' '));
             return res;
         });
 
         /**
-         * Returns a string without any dashes, since they are unauthorized
+         * Return a string without any dashes, since they are unauthorized
          * in variable names in JavaScript.
          */
-        Handlebars.default.registerHelper('removeDashes', function (str) {
+        Handlebars.default.registerHelper('slugify', function (str) {
             return str.replace(/-/g, "");
         });
     }

--- a/dahu/core/app/scripts/modules/helpers/template.js
+++ b/dahu/core/app/scripts/modules/helpers/template.js
@@ -59,6 +59,28 @@ define([
             // return URL
             return options.type + '://' + Paths.join(parts);
         });
+        
+        /**
+         * Returns a string matching the JSON object of 'element'.
+         *
+         * @param element Element to turn into a String
+         * @param indentNb Number of spaces in an indentation
+         * @param initiaIndent Number of indentations to add at the beginning of each line
+         * @returns {string} a formatted JSON object as a String.
+         */
+        Handlebars.default.registerHelper('dumpJSON', function (element, indentNb, initialIndent) {
+            var res = JSON.stringify(element, null, indentNb);
+            res = res.replace(/^/gm, Array(initialIndent*indentNb+1).join(' '));
+            return res;
+        });
+
+        /**
+         * Returns a string without any dashes, since they are unauthorized
+         * in variable names in JavaScript.
+         */
+        Handlebars.default.registerHelper('removeDashes', function (str) {
+            return str.replace(/-/g, "");
+        });
     }
 
     return {

--- a/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
+++ b/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
@@ -53,25 +53,31 @@
             {{#if this.screencast.attributes.screens.models}}
                 <!-- iterate on all the screens -->
                 {{#each this.screencast.attributes.screens.models}}
-                <section class="slide" id="screen_{{id}}">
+                <section class="slide" id="{{id}}" data-dahu-animator="anim_{{removeDashes id}}">
                     <!-- iterate on all objects, show only images -->
                     {{#each attributes.objects.models}}
                     {{#if isImage }}
                     <img src="{{attributes.img}}" class="background" style="width:{{screencastWidth}}; height:{{screencastHeight}};">
                     {{/if}}
                     {{#if isTooltip }}
-                    <div class="slide">
-                        <div class="tooltip"
-                             style="background-color: {{attributes.color}}; width: {{attributes.width}}; top:{{normalizedToPixel (screencastHeight) attributes.posy}}; left: {{normalizedToPixel (screencastWidth) attributes.posx}};">
-                            {{{attributes.text}}}
-                        </div>
+                    <div class="tooltip" id="{{attributes.id}}"
+                        style="background-color: {{attributes.color}}; width: {{attributes.width}}; top:{{normalizedToPixel (screencastHeight) attributes.posy}}; left: {{normalizedToPixel (screencastWidth) attributes.posx}};">
+                        {{{attributes.text}}}
                     </div>
                     {{/if}}
                     {{#if isMouse}}
-                    <img src="./img/cursor.png" class="mouse"
+                    <img src="./img/cursor.png" class="mouse" id="{{attributes.id}}"
                          style="top: {{normalizedToPixel (screencastHeight) attributes.posy}}; left:{{normalizedToPixel (screencastWidth) attributes.posx}};">
                     {{/if}}
                     {{/each}}
+                    <script>
+                        var anim_{{removeDashes id}} =
+                        {
+                            "target": "#{{id}}",
+                            "actions":
+{{{dumpJSON attributes.actions 4 7}}}
+                        };
+                    </script>
                 </section>
                 {{/each}}
             {{else}}
@@ -90,6 +96,8 @@
     <script src="./libs/deck.js/extensions/status/deck.status.js"></script>
     <script src="./libs/deck.js/extensions/navigation/deck.navigation.js"></script>
     <script src="./libs/deck.js/extensions/scale/deck.scale.js"></script>
+    <script src="./libs/deck.js/extensions/animator/animator.js"></script>
+    <script src="./libs/deck.js/extensions/animator/deck.animator.js"></script>
 
     <!-- Initialize the deck. You can put this in an external file if desired. -->
     <script>

--- a/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
+++ b/dahu/core/app/scripts/templates/layouts/presentation/screencast.html
@@ -53,7 +53,7 @@
             {{#if this.screencast.attributes.screens.models}}
                 <!-- iterate on all the screens -->
                 {{#each this.screencast.attributes.screens.models}}
-                <section class="slide" id="{{id}}" data-dahu-animator="anim_{{removeDashes id}}">
+                <section class="slide" id="{{id}}" data-dahu-animator="anim_{{slugify id}}">
                     <!-- iterate on all objects, show only images -->
                     {{#each attributes.objects.models}}
                     {{#if isImage }}
@@ -71,11 +71,11 @@
                     {{/if}}
                     {{/each}}
                     <script>
-                        var anim_{{removeDashes id}} =
+                        var anim_{{slugify id}} =
                         {
                             "target": "#{{id}}",
                             "actions":
-{{{dumpJSON attributes.actions 4 7}}}
+{{{stringify attributes.actions 4 7}}}
                         };
                     </script>
                 </section>

--- a/dahu/core/bower.json
+++ b/dahu/core/bower.json
@@ -16,6 +16,7 @@
     "backbone.marionette": "~2.4.1",
     "summernote": "~0.6.6",
     "deck.js": "~1.1.0",
+    "deck.ext.js": "~0.1.1",
     "jqueryui": "~1.10.4",
     "lodash": "~3.8.0",
     "fit.js": "*",


### PR DESCRIPTION
Upon building a presentation, the deck.animator plugin is included in order to be able to play the actions descripted in the project file.

The screencast template now uses this same plugin to play the animations associated to every screen in the browser.
