### PR TITLE
Fix issues #158 and #125

### DIFF
--- a/dahu/core/app/scripts/behaviors/workspace/objects/draggable.js
+++ b/dahu/core/app/scripts/behaviors/workspace/objects/draggable.js
@@ -69,6 +69,10 @@ define([
                     });
                 }
             });
+        },
+
+        onScaleChange: function(scale) {
+            this.scale = scale;
         }
     });
 

--- a/dahu/core/app/scripts/views/workspace/screen.js
+++ b/dahu/core/app/scripts/views/workspace/screen.js
@@ -35,7 +35,8 @@ define([
     MouseView,
     TooltipView,
     // templates
-    screenTemplate){
+    screenTemplate
+) {
 
     /**
      * Workspace screen view
@@ -56,6 +57,13 @@ define([
             // so that we can render the collection as children
             // of this parent node
             this.collection = this.screencast.model.getScreenById(this.screenId).get('objects');
+
+            // we save the value to update the new tooltips
+            this.lastScaleFactor = 1.0;
+        },
+
+        onAddChild: function(view) {
+            view.triggerMethod("scale:change", this.lastScaleFactor);
         },
 
         // We select the ChildView depending on the object type.
@@ -72,6 +80,7 @@ define([
         onShow: function() {
             // setup UI
             //@remove var ctrl = reqres.request('app:screencast:controller');
+            var self = this;
 
             this.$('.container').css({
                 //@remove width: ctrl.getScreencastWidth(),
@@ -88,8 +97,10 @@ define([
             }, function( transform, element ) {
                 // scale the workspace
                 fit.cssTransform(transform, element);
+                // we save the value to update the new tooltips
+                self.lastScaleFactor = transform.scale;
                 // notify listener that workspace was scaled
-                events.trigger('app:workspace:onScaleChanged', transform.scale);
+                events.trigger('app:workspace:onScaleChanged', self.lastScaleFactor);
             });
         },
 

--- a/dahu/core/app/styles/main.scss
+++ b/dahu/core/app/styles/main.scss
@@ -99,6 +99,7 @@ html, body {
         height: 100%;
 
         .container {
+            position: relative;
             // reset padding and margin added by bootstrap
             padding: 0px;
             margin: 0px;


### PR DESCRIPTION
Add an event triggered on tooltips' views to take into account the last scale
factor stored into the screen's view containing the tooltips.

Change css position of the container of a screen and its objects to be
relative to its own container.
